### PR TITLE
Add Laravel 12 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,11 +13,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.1, 8.2, 8.3]
-        laravel: [10.*, 11.*]
+        php: [8.2, 8.3, 8.4]
+        laravel: [10.*, 11.*, 12.*]
         exclude:
-          - php: 8.1
-            laravel: 11.*
+          - php: 8.4
+            laravel: 10.*
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ This package allows you to impersonate users from a landlord (main) application 
 
 ## Requirements
 
-- PHP ^8.1
-- Laravel ^10.0 or ^11.0
+- PHP ^8.2
+- Laravel ^10.0, ^11.0 or ^12.0
 - [Spatie Laravel Multitenancy](https://github.com/spatie/laravel-multitenancy) ^3.0 or ^4.0
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -19,15 +19,15 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "spatie/laravel-multitenancy": "^3.0|^4.0",
-        "illuminate/auth": "^10.0|^11.0",
-        "illuminate/database": "^10.0|^11.0",
-        "illuminate/support": "^10.0|^11.0"
+        "illuminate/auth": "^10.0|^11.0|^12.0",
+        "illuminate/database": "^10.0|^11.0|^12.0",
+        "illuminate/support": "^10.0|^11.0|^12.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
-        "orchestra/testbench": "^8.0|^9.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0",
         "phpunit/phpunit": "^10.0|^11.0"
     },
     "autoload": {


### PR DESCRIPTION
## Summary

- Add Laravel 12 support
- Update minimum PHP version to 8.2 (required by Laravel 12)

## Changes

| Dependency | Before | After |
|------------|--------|-------|
| PHP | ^8.1 | ^8.2 |
| Laravel | ^10.0\|^11.0 | ^10.0\|^11.0\|^12.0 |
| Testbench | ^8.0\|^9.0 | ^8.0\|^9.0\|^10.0 |

## CI Matrix

| PHP | Laravel 10 | Laravel 11 | Laravel 12 |
|-----|------------|------------|------------|
| 8.2 | ✓ | ✓ | ✓ |
| 8.3 | ✓ | ✓ | ✓ |
| 8.4 | ✗ | ✓ | ✓ |

## Test plan

- [x] Tests pass locally with Laravel 12
- [ ] CI passes for all matrix combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)