### PR TITLE
Add support for spatie/laravel-multitenancy v2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,9 +13,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.2, 8.3, 8.4]
-        laravel: [10.*, 11.*, 12.*]
+        php: [8.0, 8.1, 8.2, 8.3, 8.4]
+        laravel: [8.*, 9.*, 10.*, 11.*, 12.*]
         exclude:
+          - php: 8.0
+            laravel: 10.*
+          - php: 8.0
+            laravel: 11.*
+          - php: 8.0
+            laravel: 12.*
+          - php: 8.1
+            laravel: 11.*
+          - php: 8.1
+            laravel: 12.*
+          - php: 8.2
+            laravel: 8.*
+          - php: 8.2
+            laravel: 9.*
+          - php: 8.3
+            laravel: 8.*
+          - php: 8.3
+            laravel: 9.*
+          - php: 8.4
+            laravel: 8.*
+          - php: 8.4
+            laravel: 9.*
           - php: 8.4
             laravel: 10.*
 

--- a/composer.json
+++ b/composer.json
@@ -19,16 +19,16 @@
         }
     ],
     "require": {
-        "php": "^8.2",
-        "spatie/laravel-multitenancy": "^3.0|^4.0",
-        "illuminate/auth": "^10.0|^11.0|^12.0",
-        "illuminate/database": "^10.0|^11.0|^12.0",
-        "illuminate/support": "^10.0|^11.0|^12.0"
+        "php": "^8.0",
+        "spatie/laravel-multitenancy": "^2.0|^3.0|^4.0",
+        "illuminate/auth": "^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/database": "^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
-        "orchestra/testbench": "^8.0|^9.0|^10.0",
-        "phpunit/phpunit": "^10.0|^11.0"
+        "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0|^10.0",
+        "phpunit/phpunit": "^9.0|^10.0|^11.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary
- Adds `spatie/laravel-multitenancy ^2.0` support alongside existing `^3.0|^4.0`
- Lowers PHP requirement to `^8.0` and adds Laravel 8-9 support
- Expands CI matrix to cover PHP 8.0-8.4 with Laravel 8-12, with exclusions for incompatible combinations

## Test plan
- [x] `composer validate` passes
- [x] All 12 existing tests pass locally
- [ ] CI matrix runs successfully across all PHP/Laravel combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)